### PR TITLE
Plugin used Ogre classes in the headers while having only forward dec…

### DIFF
--- a/Plugins/ParticleUniverse/include/ParticleUniverseTypes.h
+++ b/Plugins/ParticleUniverse/include/ParticleUniverseTypes.h
@@ -28,7 +28,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "OgrePrerequisites.h"
 #include "OgreString.h"
 #include "OgreStringVector.h"
+#include "OgreQuaternion.h"
 #include "OgreVector2.h"
+#include "OgreVector3.h"
+#include "OgreVector4.h"
+#include "OgreColourValue.h"
 
 namespace ParticleUniverse
 {


### PR DESCRIPTION
…lared them. Added basic types from Ogre headers to avoid compilation issues that can arise from it in our project.

At least Ogre::ColourValue gets used without proper header in the current official version, if the project that you're using particleuniverse on has not included OgreColourValue header:

Particleuniverse\ParticleUniverseVisualParticle.h(32) : error C2079: 'ParticleUniverse::VisualParticle::originalColour' uses undefined class 'Ogre::ColourValue'