### PR TITLE
Ogre 2.1

### DIFF
--- a/Plugins/ParticleUniverse/include/ParticleRenderers/ParticleUniversePrimitiveShapeSet.h
+++ b/Plugins/ParticleUniverse/include/ParticleRenderers/ParticleUniversePrimitiveShapeSet.h
@@ -142,10 +142,6 @@ namespace ParticleUniverse
 		    */
 			virtual void rotateTexture(Real speed);
 
-			/** @see MovableObject
-		    */
-			virtual void visitRenderables(Ogre::Renderable::Visitor* visitor,
-				bool debugRenderables = false) {/* No implementation */};
 	};
 
 }

--- a/Plugins/ParticleUniverse/include/ParticleUniverseAttachable.h
+++ b/Plugins/ParticleUniverse/include/ParticleUniverseAttachable.h
@@ -78,11 +78,6 @@ namespace ParticleUniverse
 			*/
 			virtual void _updateRenderQueue(Ogre::RenderQueue* queue, Ogre::Camera* camera, const Ogre::Camera* lodCamera);
 
-			/** @see MovableObject
-		    */
-			virtual void visitRenderables(Ogre::Renderable::Visitor* visitor,
-				bool debugRenderables = false) {/* No implementation */};
-
 			/** Copy attributes to another Extern object.
 	        */
 			virtual void copyAttributesTo (Extern* externObject);

--- a/Plugins/ParticleUniverse/include/ParticleUniverseSystem.h
+++ b/Plugins/ParticleUniverse/include/ParticleUniverseSystem.h
@@ -470,11 +470,6 @@ namespace ParticleUniverse
 			*/
 			void pushEvent(ParticleUniverseEvent& particleUniverseEvent);
 
-			/** @see MovableObject
-		    */
-			virtual void visitRenderables (Ogre::Renderable::Visitor* visitor,
-				bool debugRenderables = false) {/* No implementation */};
-
 			/** Returns the time of a pause (if set)
 			*/
 			Real getPauseTime (void) const;

--- a/Plugins/ParticleUniverse/src/ParticleRenderers/ParticleUniverseBoxSet.cpp
+++ b/Plugins/ParticleUniverse/src/ParticleRenderers/ParticleUniverseBoxSet.cpp
@@ -301,7 +301,7 @@ namespace ParticleUniverse
 	{
 		op.vertexData = mVertexData;
 		op.vertexData->vertexStart = 0;
-		op.operationType = Ogre::v1::RenderOperation::OT_TRIANGLE_LIST;
+		op.operationType = Ogre::OT_TRIANGLE_LIST;
 		op.useIndexes = true;
 		op.vertexData->vertexCount = mNumVisibleBoxes * 16;
 		op.indexData = mIndexData;

--- a/Plugins/ParticleUniverse/src/ParticleRenderers/ParticleUniverseSphereSet.cpp
+++ b/Plugins/ParticleUniverse/src/ParticleRenderers/ParticleUniverseSphereSet.cpp
@@ -310,7 +310,7 @@ namespace ParticleUniverse
 	{
 		op.vertexData = mVertexData;
 		op.vertexData->vertexStart = 0;
-		op.operationType = Ogre::v1::RenderOperation::OT_TRIANGLE_LIST;
+		op.operationType = Ogre::OT_TRIANGLE_LIST;
 		op.useIndexes = true;
 		op.vertexData->vertexCount = mNumVisibleSpheres * mVertexCountPerSphere;
 		op.indexData = mIndexData;


### PR DESCRIPTION
1. Removed 'visitRenderables' method. Link to ogre commit connected to this change: 
https://bitbucket.org/sinbad/ogre/commits/52725e1098b4aa308daa7857d39f42e2334b9025
2. Enum Ogre::OperationType is now in 'OgreHlmsPso.h' file.

This is enogh to compile plugin dll.
I am unable to compile sample unless I add two paths to CXX_INCLUDES in <build_folder>/Samples\ParticleUniverseDemo\CMakeFiles\particleuniversedemo.dir\flags.make ( <ogre_src>\Components\Hlms\Unlit\include and Components\Hlms\Common\include).
I need also to change line #include <Hlms\Unlit\OgreHlmsUnlit.h> to #include <..\Components\Hlms\Unlit\include\OgreHlmsUnlit.h> in BaseApplication.cpp to make it compile.